### PR TITLE
New endpoint /all-disturbances

### DIFF
--- a/source/php/Api/AllDisturbances.php
+++ b/source/php/Api/AllDisturbances.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ApiAlarmManager\Api;
+
+use WpService\Contracts\AddAction;
+use WpService\Contracts\GetOption;
+use WpService\Contracts\GetTerm;
+use WpService\Contracts\RegisterRestRoute;
+use AcfService\Contracts\GetField;
+use AcfService\Contracts\UpdateField;
+
+class AllDisturbances extends \ApiAlarmManager\Entity\ApiFields
+{
+    private $namespace = 'wp/v2';
+    private $route     = '/all-disturbances';
+
+    public function __construct(
+        private GetOption&AddAction&RegisterRestRoute&GetTerm $wpService,
+        private GetField&UpdateField $acfService
+    ) {
+        $this->wpService->addAction('rest_api_init', array($this, 'registerEndpoint'));
+    }
+
+    public function registerEndpoint()
+    {
+        $this->wpService->registerRestRoute($this->namespace, $this->route, array(
+            'methods'  => 'GET',
+            'callback' => array($this, 'getApiResponse'),
+        ));
+    }
+
+    public function getApiResponse(\WP_REST_Request $request): array
+    {
+        $api_1 = new Disturbances($this->wpService, $this->acfService);
+        $api_2 = new FireDangerLevels($this->wpService, $this->acfService);
+
+        return [
+            'disturbances'    => $api_1->getDisturbances($request),
+            'firedangerlevel' => $api_2->getFireDangerLevels($request),
+        ];
+    }
+}

--- a/source/php/Api/BigDisturbanceFields.php
+++ b/source/php/Api/BigDisturbanceFields.php
@@ -50,16 +50,16 @@ class BigDisturbanceFields extends \ApiAlarmManager\Entity\ApiFields
                     foreach ($alarmIds as $alarmId) {
                         $alarms[$alarmId] = array(
                             'title' => get_the_title($alarmId),
-                            'href' => rest_url('/wp/v2/alarm/' . $alarmId)
+                            'href'  => rest_url('/wp/v2/alarm/' . $alarmId)
                         );
                     }
 
                     return $alarms;
                 },
-                'schema' => array(
+                'schema'       => array(
                     'description' => 'Field containing alarms connected to the disturbance.',
-                    'type' => 'string',
-                    'context' => array('view', 'edit')
+                    'type'        => 'string',
+                    'context'     => array('view', 'edit')
                 )
             )
         );
@@ -72,10 +72,10 @@ class BigDisturbanceFields extends \ApiAlarmManager\Entity\ApiFields
                 'get_callback' => function ($object, $field_name, $request, $formatted = true) {
                     return wp_get_post_terms($object['id'], 'place');
                 },
-                'schema' => array(
+                'schema'       => array(
                     'description' => 'Field containing alarm place taxonomy terms.',
-                    'type' => 'string',
-                    'context' => array('view', 'edit')
+                    'type'        => 'string',
+                    'context'     => array('view', 'edit')
                 )
             )
         );

--- a/source/php/Api/Disturbances.php
+++ b/source/php/Api/Disturbances.php
@@ -2,44 +2,55 @@
 
 namespace ApiAlarmManager\Api;
 
+use WpService\Contracts\AddAction;
+use WpService\Contracts\GetOption;
+use WpService\Contracts\GetTerm;
+use WpService\Contracts\RegisterRestRoute;
+use AcfService\Contracts\GetField;
+use AcfService\Contracts\UpdateField;
+
 class Disturbances
 {
-    public function __construct()
-    {
-        add_action('rest_api_init', array($this, 'registerEndpoint'));
-        add_action('rest_api_init', array($this, 'setCacheHeader'), 15);
+    public function __construct(
+        private GetOption&AddAction&RegisterRestRoute&GetTerm $wpService,
+        private GetField&UpdateField $acfService
+    ) {
+        $this->wpService->addAction('rest_api_init', array($this, 'registerEndpoint'));
+        $this->wpService->addAction('rest_api_init', array($this, 'setCacheHeader'), 15);
     }
 
     public function registerEndpoint()
     {
         register_rest_route('wp/v2', '/disturbances', array(
-            'methods' => 'GET',
-            'callback' => array($this, 'getDisturbances'),
+        'methods'  => 'GET',
+        'callback' => array($this, 'getDisturbances'),
         ));
     }
 
-    public function setCacheHeader() {
-        remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
-        add_filter( 'rest_pre_serve_request', function( $value ) {
+    public function setCacheHeader()
+    {
+        remove_filter('rest_pre_serve_request', 'rest_send_cors_headers');
+        add_filter('rest_pre_serve_request', function ($value) {
             header('Cache-Control: max-age=300');
 
             return $value;
         });
     }
 
-    public function getDisturbances($data)
+    public function getDisturbances(\WP_REST_Request $request)
     {
-        $args = array(
-            'post_status' => 'publish',
+        $args  = array(
+            'post_status'    => 'publish',
             'posts_per_page' => -1
         );
+        $place = $request->get_param('place');
 
-        if (isset($_GET['place']) && !empty($_GET['place'])) {
+        if (isset($place) && !empty($place)) {
             $args['tax_query'] = array(
                 'relation' => 'AND',
                 array(
                     'taxonomy' => 'place',
-                    'terms' => explode(',', $_GET['place']),
+                    'terms'    => explode(',', $place),
                 )
             );
         }
@@ -64,7 +75,7 @@ class Disturbances
         }
 
         return array(
-            'big' => $big->posts,
+            'big'   => $big->posts,
             'small' => $small->posts
         );
     }
@@ -76,17 +87,16 @@ class Disturbances
      */
     public function getAlarmConnection($disturbance)
     {
-        $alarmIds = get_field('alarm_connection', $disturbance->ID);
-        $alarms = array();
+        $alarmIds = $this->acfService->getField('alarm_connection', $disturbance->ID);
+        $alarms   = array();
 
         if (!is_array($alarmIds)) {
             return $alarms;
         }
-
         foreach ($alarmIds as $alarmId) {
             $alarms[$alarmId] = array(
                 'title' => get_the_title($alarmId),
-                'href' => rest_url('/wp/v2/alarm/' . $alarmId)
+                'href'  => rest_url('/wp/v2/alarm/' . $alarmId)
             );
         }
 

--- a/source/php/Api/FireDangerLevelTest.php
+++ b/source/php/Api/FireDangerLevelTest.php
@@ -4,13 +4,10 @@ namespace ApiAlarmManager\Api;
 
 use AcfService\Implementations\FakeAcfService;
 use ApiAlarmManager\Api\FireDangerLevels;
-use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use WP_REST_Request;
 use WP_Term;
 use WpService\Implementations\FakeWpService;
-
-use function PHPUnit\Framework\assertEquals;
 
 class FireDangerLevelTest extends TestCase
 {
@@ -56,42 +53,45 @@ class FireDangerLevelTest extends TestCase
             $this->service = new FireDangerLevels($wpService, $acfService);
     }
 
-    public function testWithSingleFilterValue()
+    public function testWithSinglePlaceFilterValue()
     {
         $wpRequest = $this->createMock(WP_REST_Request::class);
-        $wpRequest->method('get_param')->willReturn('Klippan');
+
+        $wpRequest->method('get_param')->willReturnCallback(function ($key) {
+            switch ($key) {
+                case 'place':
+                    return '2';
+                case 'level':
+                    return '0';
+                default:
+                    return null;
+            }
+        });
 
         $result = $this->service->getFireDangerLevels($wpRequest);
 
         $this->assertCount(1, $result['places']);
-
-        $items =  array_slice($result['places'], 0, 1);
-        $this->assertEquals('Klippan', $items[0]['place']);
+        $this->assertEquals('Klippan', $result['places'][0]['place']);
     }
-    public function testWithSingleFilterValueCaseInsensitive()
+    public function testWithMultiplePlaceFilterValues()
     {
         $wpRequest = $this->createMock(WP_REST_Request::class);
-        $wpRequest->method('get_param')->willReturn('klippan');
 
-        $result = $this->service->getFireDangerLevels($wpRequest);
-
-        $this->assertCount(1, $result['places']);
-
-        $items =  array_slice($result['places'], 0, 1);
-        $this->assertEquals('Klippan', $items[0]['place']);
-    }
-    public function testMultipleFilterValues()
-    {
-        $wpRequest = $this->createMock(WP_REST_Request::class);
-        $wpRequest->method('get_param')->willReturn('Klippan,Helsingborg');
-
+        $wpRequest->method('get_param')->willReturnCallback(function ($key) {
+            switch ($key) {
+                case 'place':
+                    return '2,1';
+                case 'level':
+                    return 0;
+                default:
+                    return null;
+            }
+        });
         $result = $this->service->getFireDangerLevels($wpRequest);
 
         $this->assertCount(2, $result['places']);
-
-        $items =  array_slice($result['places'], 0, 2);
-        $this->assertEquals('Helsingborg', $items[0]['place']);
-        $this->assertEquals('Klippan', $items[1]['place']);
+        $this->assertEquals('Helsingborg', $result['places'][0]['place']);
+        $this->assertEquals('Klippan', $result['places'][1]['place']);
     }
     public function testWithoutFilterValues()
     {
@@ -100,5 +100,39 @@ class FireDangerLevelTest extends TestCase
         $result = $this->service->getFireDangerLevels($wpRequest);
 
         $this->assertCount(3, $result['places']);
+    }
+    public function testWithSingleLevelFilterValue()
+    {
+        $wpRequest = $this->createMock(WP_REST_Request::class);
+
+        $wpRequest->method('get_param')->willReturnCallback(function ($key) {
+            switch ($key) {
+                case 'level':
+                    return '1';
+                default:
+                    return null;
+            }
+        });
+        $result = $this->service->getFireDangerLevels($wpRequest);
+
+        $this->assertCount(1, $result['places']);
+    }
+    public function testMultipleLevelFilterValues()
+    {
+        $wpRequest = $this->createMock(WP_REST_Request::class);
+
+        $wpRequest->method('get_param')->willReturnCallback(function ($key) {
+            switch ($key) {
+                case 'level':
+                    return '1,2';
+                default:
+                    return null;
+            }
+        });
+        $result = $this->service->getFireDangerLevels($wpRequest);
+
+        $this->assertCount(2, $result['places']);
+        $this->assertEquals('Helsingborg', $result['places'][0]['place']);
+        $this->assertEquals('Klippan', $result['places'][1]['place']);
     }
 }

--- a/source/php/App.php
+++ b/source/php/App.php
@@ -29,14 +29,14 @@ class App
         new Api\PostTypes();
         new Api\Taxonomies();
         new Api\Linking();
-        new Api\Disturbances();
+        new Api\Disturbances($this->wpService, $this->acfService);
         new Api\FireDangerLevels($this->wpService, $this->acfService);
-
         new Api\AlarmFields();
         new Api\AlarmFilters();
         new Api\StationFields();
         new Api\SmallDisturbanceFields();
         new Api\BigDisturbanceFields();
+        new Api\AllDisturbances($this->wpService, $this->acfService);
 
         // Misc
         if (is_admin()) {


### PR DESCRIPTION
Disturbances and fire warnings can be retrieved simultaneously through:

/json/wp/v2/all-disturbances?place=4,3,5&level=2,1

The "place" parameter filter applies to both the disturbance & firedanger API. "level" is only applicable for firedanger

The response is divided in two sections:

disturbances: { big: [], small: []}

and

firedangerlevel: {}
